### PR TITLE
Fixing IQueryable so that queries happen in mongo

### DIFF
--- a/src/MongoDB.AspNet.Identity/UserStore.cs
+++ b/src/MongoDB.AspNet.Identity/UserStore.cs
@@ -87,7 +87,7 @@ namespace MongoDB.AspNet.Identity
         {
             get
             {
-                return db.GetCollection<TUser>(collectionName).FindAll().AsQueryable();
+                return db.GetCollection<TUser>(collectionName).AsQueryable();
             }
         }
 


### PR DESCRIPTION
Before the query was pulling down all the users from mongo and then querying on them linq to objects style which would not scale if you have more than a handful of users.

This being said I really don't think there was any need to update queries to be Linq queries as it doesn't buy you anything.  Doesn't hurt or help for simple queries.  For more complex queries using Linq does not always work as the linq provider has some edge cases that throw errors.
